### PR TITLE
[feat] 유저 API 기능 구현 #20

### DIFF
--- a/src/main/java/org/example/outsourcing/ServerApplication.java
+++ b/src/main/java/org/example/outsourcing/ServerApplication.java
@@ -2,8 +2,10 @@ package org.example.outsourcing;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class ServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/example/outsourcing/common/config/SecurityConfig.java
+++ b/src/main/java/org/example/outsourcing/common/config/SecurityConfig.java
@@ -46,9 +46,9 @@ public class SecurityConfig {
 				sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			)
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers(HttpMethod.POST,
+				.requestMatchers(
 					"/api/auth/signin",
-					"/api/users/signup"
+					"/api/users"
 				).permitAll()
 				.requestMatchers(HttpMethod.GET,
 					"/api/auth/oauth2/signin/google"

--- a/src/main/java/org/example/outsourcing/common/filter/BaseJwtFilter.java
+++ b/src/main/java/org/example/outsourcing/common/filter/BaseJwtFilter.java
@@ -2,6 +2,8 @@ package org.example.outsourcing.common.filter;
 
 import java.io.IOException;
 
+import org.example.outsourcing.common.filter.exception.FilterException;
+import org.example.outsourcing.common.filter.exception.FilterExceptionCode;
 import org.example.outsourcing.domain.auth.dto.UserAuth;
 import org.example.outsourcing.jwt.constants.JwtConstants;
 import org.example.outsourcing.jwt.service.JwtService;
@@ -34,13 +36,13 @@ public abstract class BaseJwtFilter extends OncePerRequestFilter {
 
 		String authorization = getTokenFromRequest(request);
 		if (authorization == null || authorization.isBlank()) {
-			//throw new
+			throw new FilterException(FilterExceptionCode.EMPTY_TOKEN);
 		}
 
 		String token = resolveToken(authorization);
 
 		if (jwtService.isTokenExpired(token)) {
-			//throw new
+			throw new FilterException(FilterExceptionCode.TOKEN_EXPIRED);
 		}
 
 		UserAuth userAuth = jwtService.getUserAuth(token);
@@ -57,7 +59,7 @@ public abstract class BaseJwtFilter extends OncePerRequestFilter {
 
 	private String resolveToken(String authorization) {
 		if (!authorization.startsWith(JwtConstants.TOKEN_PREFIX)) {
-
+			throw new FilterException(FilterExceptionCode.INVALID_TOKEN_USAGE);
 		}
 		return authorization.substring(JwtConstants.TOKEN_PREFIX.length());
 	}

--- a/src/main/java/org/example/outsourcing/common/filter/constants/FilterConstants.java
+++ b/src/main/java/org/example/outsourcing/common/filter/constants/FilterConstants.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class FilterConstants {
 
-	public static final List<String> WHITE_LIST = List.of("/api/auth/signin", "/api/users/signup",
+	public static final List<String> WHITE_LIST = List.of("/api/auth/signin", "/api/users",
 		"/api/auth/oauth2/signin/google");
 	public static final String REISSUE = "/api/reissue";
 }

--- a/src/main/java/org/example/outsourcing/common/filter/exception/FilterExceptionCode.java
+++ b/src/main/java/org/example/outsourcing/common/filter/exception/FilterExceptionCode.java
@@ -9,11 +9,13 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum FilterExceptionCode implements ResponseCode {
+
 	TOKEN_EXPIRED(false, HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
 	EMPTY_TOKEN(false, HttpStatus.UNAUTHORIZED, "헤더에 토큰을 포함하고 있지 않습니다."),
 	MALFORMED_JWT_REQUEST(false, HttpStatus.UNAUTHORIZED, "요청 형태가 잘못 되었습니다."),
 	CANT_USE_TOKEN(false, HttpStatus.UNAUTHORIZED, "사용할 수 없는 토큰입니다."),
 	INVALID_TOKEN_USAGE(false, HttpStatus.FORBIDDEN, "잘못된 유형의 토큰입니다.");
+
 	private final boolean success;
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/org/example/outsourcing/domain/user/controller/UserController.java
+++ b/src/main/java/org/example/outsourcing/domain/user/controller/UserController.java
@@ -1,0 +1,38 @@
+package org.example.outsourcing.domain.user.controller;
+
+import org.example.outsourcing.common.annotation.ResponseMessage;
+import org.example.outsourcing.domain.user.dto.UserDeleteRequest;
+import org.example.outsourcing.domain.user.dto.UserResponse;
+import org.example.outsourcing.domain.user.dto.UserSaveRequest;
+import org.example.outsourcing.domain.user.service.UserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class UserController {
+
+	private final UserService userService;
+
+	@PostMapping
+	@ResponseMessage("정상적으로 가입처리 되었습니다.")
+	public ResponseEntity<UserResponse> createUser(@RequestBody @Validated UserSaveRequest request) {
+		return ResponseEntity.status(HttpStatus.CREATED).body(userService.createUser(request));
+	}
+
+	@DeleteMapping
+	@ResponseMessage("정상적으로 탈퇴처리 되었습니다.")
+	public ResponseEntity<Void> withDrawUser(@RequestBody @Validated UserDeleteRequest request) {
+		userService.withDrawUser(request);
+		return ResponseEntity.ok().build();
+	}
+}

--- a/src/main/java/org/example/outsourcing/domain/user/dto/UserDeleteRequest.java
+++ b/src/main/java/org/example/outsourcing/domain/user/dto/UserDeleteRequest.java
@@ -1,0 +1,14 @@
+package org.example.outsourcing.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UserDeleteRequest(
+
+	@NotBlank
+	String email,
+	@NotBlank
+	String password
+
+) {
+}
+

--- a/src/main/java/org/example/outsourcing/domain/user/dto/UserResponse.java
+++ b/src/main/java/org/example/outsourcing/domain/user/dto/UserResponse.java
@@ -1,0 +1,22 @@
+package org.example.outsourcing.domain.user.dto;
+
+import java.time.LocalDateTime;
+
+import org.example.outsourcing.domain.user.entity.User;
+
+import lombok.Builder;
+
+@Builder
+public record UserResponse(
+
+	String email,
+	LocalDateTime createdAt
+
+) {
+	public static UserResponse from(User user) {
+		return UserResponse.builder()
+			.email(user.getEmail())
+			.createdAt(user.getCreatedAt())
+			.build();
+	}
+}

--- a/src/main/java/org/example/outsourcing/domain/user/dto/UserSaveRequest.java
+++ b/src/main/java/org/example/outsourcing/domain/user/dto/UserSaveRequest.java
@@ -1,0 +1,32 @@
+package org.example.outsourcing.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UserSaveRequest(
+
+	@NotBlank(message = "이메일을 필수 입력값입니다.")
+	@Email(message = "올바른 이메일 형식이 아닙니다.")
+	String email,
+
+	@NotBlank(message = "이름을 필수 입력값입니다.")
+	@Size(max = 20, message = "이름 최대 20글자가 넘지 않도록 해주십시오.")
+	String name,
+
+	@NotBlank(message = "비밀번호는 필수 입력값입니다.")
+	@Pattern(
+		regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()\\-_=+{};:,<.>]).{8,}$",
+		message = "비밀번호는 최소 8자 이상이며, 대문자, 소문자, 숫자, 특수문자를 모두 포함해야 합니다"
+	)
+	String password,
+
+	@NotBlank
+	@Pattern(regexp = "^(admin|owner|user)$",
+		message = "Role 입력값은 admin, owner, user 중 하나여야 합니다.")
+	String role,
+	String profileImgUrl
+
+) {
+}

--- a/src/main/java/org/example/outsourcing/domain/user/entity/Platform.java
+++ b/src/main/java/org/example/outsourcing/domain/user/entity/Platform.java
@@ -1,6 +1,6 @@
 package org.example.outsourcing.domain.user.entity;
 
 public enum Platform {
-	GOOGLE, KAKAO, NAVER
+	GOOGLE, KAKAO, NAVER, LOCAL
 }
 

--- a/src/main/java/org/example/outsourcing/domain/user/entity/User.java
+++ b/src/main/java/org/example/outsourcing/domain/user/entity/User.java
@@ -1,6 +1,5 @@
 package org.example.outsourcing.domain.user.entity;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -50,7 +49,7 @@ public class User extends BaseEntity {
 	private boolean isDeleted;
 
 	@Column
-	private String profile_img_url;
+	private String profileImgUrl;
 
 	@Enumerated(EnumType.STRING)
 	private Platform platform;
@@ -58,6 +57,7 @@ public class User extends BaseEntity {
 	public void withdraw() {
 		this.name = "deleted user" + UUID.randomUUID();
 		this.isDeleted = true;
+		this.roles.clear();
 	}
 
 	public void changePassword(String newPassword) {

--- a/src/main/java/org/example/outsourcing/domain/user/entity/UserRole.java
+++ b/src/main/java/org/example/outsourcing/domain/user/entity/UserRole.java
@@ -1,11 +1,22 @@
 package org.example.outsourcing.domain.user.entity;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import java.util.function.Predicate;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class UserRole {
-	public static final String ADMIN = "ROLE_admin";
-	public static final String OWNER = "ROLE_owner";
-	public static final String USER = "ROLE_user";
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserRole {
+
+	ADMIN("ROLE_admin", "admin"::equals),
+	USER("ROLE_user", "user"::equals),
+	OWNER("ROLE_owner", "owner"::equals);
+
+	private final String role;
+	private final Predicate<String> func;
+
+	public boolean matches(String role) {
+		return func.test(role);
+	}
 }

--- a/src/main/java/org/example/outsourcing/domain/user/exception/UserException.java
+++ b/src/main/java/org/example/outsourcing/domain/user/exception/UserException.java
@@ -1,4 +1,4 @@
-package org.example.outsourcing.common.filter.exception;
+package org.example.outsourcing.domain.user.exception;
 
 import org.example.outsourcing.common.exception.BaseException;
 import org.example.outsourcing.common.exception.ResponseCode;
@@ -7,12 +7,14 @@ import org.springframework.http.HttpStatus;
 import lombok.Getter;
 
 @Getter
-public class FilterException extends BaseException {
+public class UserException extends BaseException {
+
 	private final ResponseCode responseCode;
 	private final HttpStatus httpStatus;
 
-	public FilterException(ResponseCode responseCode) {
+	public UserException(ResponseCode responseCode) {
 		this.responseCode = responseCode;
 		this.httpStatus = responseCode.getStatus();
 	}
+
 }

--- a/src/main/java/org/example/outsourcing/domain/user/exception/UserExceptionCode.java
+++ b/src/main/java/org/example/outsourcing/domain/user/exception/UserExceptionCode.java
@@ -1,0 +1,23 @@
+package org.example.outsourcing.domain.user.exception;
+
+import org.example.outsourcing.common.exception.ResponseCode;
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserExceptionCode implements ResponseCode {
+
+	WRONG_PASSWORD(false, HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸습니다."),
+	SAME_PASSWORD(false, HttpStatus.CONFLICT, "기존과 동일한 비밀번호로 수정할 수 없습니다."),
+	NOT_CHANGED(false, HttpStatus.BAD_REQUEST, "수정 사항이 존재하지 않습니다."),
+	USER_NOT_FOUND(false, HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
+	ALREADY_EXISTS_EMAIL(false, HttpStatus.CONFLICT, "이미 존재하는 이메일이 있습니다."),
+	WITHDRAWN_USER(false, HttpStatus.UNAUTHORIZED, "이미 탈퇴한 유저입니다.");
+
+	private final boolean isSuccess;
+	private final HttpStatus status;
+	private final String message;
+}

--- a/src/main/java/org/example/outsourcing/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/outsourcing/domain/user/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package org.example.outsourcing.domain.user.repository;
+
+import java.util.Optional;
+
+import org.example.outsourcing.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+	boolean existsByEmail(String email);
+
+	Optional<User> findByEmailAndIsDeleted(String email, boolean isDeleted);
+
+}

--- a/src/main/java/org/example/outsourcing/domain/user/service/UserService.java
+++ b/src/main/java/org/example/outsourcing/domain/user/service/UserService.java
@@ -1,0 +1,76 @@
+package org.example.outsourcing.domain.user.service;
+
+import java.util.Arrays;
+
+import org.example.outsourcing.domain.user.dto.UserDeleteRequest;
+import org.example.outsourcing.domain.user.dto.UserResponse;
+import org.example.outsourcing.domain.user.dto.UserSaveRequest;
+import org.example.outsourcing.domain.user.entity.Platform;
+import org.example.outsourcing.domain.user.entity.User;
+import org.example.outsourcing.domain.user.entity.UserRole;
+import org.example.outsourcing.domain.user.exception.UserException;
+import org.example.outsourcing.domain.user.exception.UserExceptionCode;
+import org.example.outsourcing.domain.user.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	@Transactional
+	public UserResponse createUser(UserSaveRequest request) {
+
+		checkEmail(request.email());
+
+		User user = userRepository.save(
+			User.builder()
+				.email(request.email())
+				.name(request.name())
+				.password(passwordEncoder.encode(request.password()))
+				.roles(
+					Arrays.stream(UserRole.values())
+						.filter(role -> role.matches(request.role()))
+						.map(UserRole::getRole)
+						.toList()
+				)
+				.profileImgUrl(request.profileImgUrl())
+				.platform(Platform.LOCAL)
+				.build()
+		);
+		return UserResponse.from(user);
+	}
+
+	@Transactional
+	public void withDrawUser(UserDeleteRequest request) {
+
+		User user = userRepository.findByEmailAndIsDeleted(request.email(), false)
+			.orElseThrow(() -> new UserException(UserExceptionCode.USER_NOT_FOUND));
+
+		checkPassword(request.password(), user.getPassword());
+
+		user.withdraw();
+	}
+
+	private void checkEmail(String email) {
+
+		if (userRepository.existsByEmail(email)) {
+			throw new UserException(UserExceptionCode.ALREADY_EXISTS_EMAIL);
+		}
+	}
+
+	private void checkPassword(String rawPassword, String hashedPassword) {
+
+		if (!passwordEncoder.matches(rawPassword, hashedPassword)) {
+			throw new UserException(UserExceptionCode.WRONG_PASSWORD);
+		}
+
+	}
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #20   <!-- 연결된 이슈 번호 기재 -->



## ✨ 기능 요약

계정 생성 및 탈퇴  기능 구현


<!--
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | 기능 이름을 간단히 요약 |
| 🔍 목적 | 해당 기능이 왜 필요한지 간략 설명 |
| 🛠️ 변경사항 | 핵심 변경 포인트 간략히 요약 (예: UI 추가, API 연동 등) |
--> 


## 📝 상세 내역
<!--
| 번호 | 내용 |
|------|------|
| 1️⃣ | 주요 로직/컴포넌트/서비스 등 변경 설명 |
| 2️⃣ | 관련 유틸, 공통 로직 수정 여부 |
| 3️⃣ | 리팩토링 또는 제거된 불필요 코드 |
--> 


## ✅ 테스트 체크리스트
<!-- 테스트 할 내용이 있다면 작성해주세요
- [ ] 기능 정상 작동 확인
- [ ] 예외/엣지 케이스 확인
- [ ] UI/UX 흐름 확인 (필요 시 캡처 또는 영상 첨부)
- [ ] 테스트 코드 작성 완료
- [ ] API 연동 확인 (요청/응답 정상 동작)
--> 


## 📸 포스트맨 캡처 사진

![image](https://github.com/user-attachments/assets/9343204c-04df-47ec-9c45-2618e3e24bb4)



## 🙋‍♀️ 리뷰어 참고사항

요약 내용 대로 계정 생성 및 탈퇴 기능 관련입니다.
관련해서 필요한 예외들과 필요할 것 같은 예외들도 추가했습니다.

계정의 role 같은 경우에는 추후 컨트롤러에서 접근제어 용도로 활용하시면 좋을 듯 합니다.
현재는 admin, owner,user 만 있고 따로 role 더 필요하시면 요청주시면 추가하도록하겠습니다.


<!-- 
- 테스트 방법
- 주요 로직 설명
- 리뷰 시 중점적으로 봐주셨으면 하는 부분
- 코드 스타일 관련 사항 등
--> 
