### PR TITLE
[feat] #19 리뷰 API 구현

### DIFF
--- a/src/main/java/org/example/outsourcing/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/outsourcing/common/advice/GlobalExceptionHandler.java
@@ -1,0 +1,36 @@
+package org.example.outsourcing.common.advice;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.outsourcing.common.dto.CommonResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.validation.FieldError;
+
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<CommonResponse<Void>> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException e,
+            HttpServletRequest request
+    ) {
+        log.error("Validation failed: {}", e.getMessage());
+
+        String errorMessage = e.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(FieldError::getDefaultMessage)
+                .orElse("잘못된 요청입니다.");
+
+        return ResponseEntity
+                .badRequest()
+                .body(CommonResponse.of(false, errorMessage, 400, null));
+    }
+
+}

--- a/src/main/java/org/example/outsourcing/domain/order/entity/Order.java
+++ b/src/main/java/org/example/outsourcing/domain/order/entity/Order.java
@@ -9,7 +9,7 @@ import org.example.outsourcing.domain.user.entity.User;
 
 @Getter
 @Entity
-@Table(name = "order")
+@Table(name = "orders")
 @AllArgsConstructor
 @NoArgsConstructor
 public class Order {

--- a/src/main/java/org/example/outsourcing/domain/order/repository/OrderRepository.java
+++ b/src/main/java/org/example/outsourcing/domain/order/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package org.example.outsourcing.domain.order.repository;
+
+import org.example.outsourcing.domain.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/org/example/outsourcing/domain/review/controller/ReviewController.java
+++ b/src/main/java/org/example/outsourcing/domain/review/controller/ReviewController.java
@@ -1,0 +1,43 @@
+package org.example.outsourcing.domain.review.controller;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.example.outsourcing.common.annotation.ResponseMessage;
+import org.example.outsourcing.domain.review.dto.request.ReviewRequestDto;
+import org.example.outsourcing.domain.review.dto.response.ReviewResponseDto;
+import org.example.outsourcing.domain.review.service.ReviewService;
+import org.example.outsourcing.domain.user.entity.User;
+import org.example.outsourcing.domain.user.repository.UserRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/reviews")
+@RequiredArgsConstructor
+public class ReviewController {
+    private final ReviewService reviewService;
+    private final UserRepository userRepository;
+
+    @PostMapping
+    @ResponseMessage("리뷰가 성공적으로 작성되었습니다.")
+    public ReviewRequestDto createReview(@RequestBody ReviewRequestDto reviewRequestDto) {
+        User user = userRepository.findById(1L)
+                .orElseThrow(() -> new EntityNotFoundException("테스트 유저 없음"));
+        reviewService.createReview(user.getId(), reviewRequestDto);
+        return reviewRequestDto;
+    }
+
+    @GetMapping
+    @ResponseMessage("가게 별 리뷰목록을 성공적으로 조회했습니다.")
+    public ResponseEntity<List<ReviewResponseDto>> getReviews(
+            @RequestParam Long storeId,
+            @RequestParam(defaultValue = "1") int minRating,
+            @RequestParam(defaultValue = "5") int maxRating
+    ) {
+        List<ReviewResponseDto> reviews = reviewService.getReviewList(storeId, minRating, maxRating);
+        return ResponseEntity.ok(reviews);
+    }
+
+}

--- a/src/main/java/org/example/outsourcing/domain/review/controller/ReviewController.java
+++ b/src/main/java/org/example/outsourcing/domain/review/controller/ReviewController.java
@@ -1,6 +1,7 @@
 package org.example.outsourcing.domain.review.controller;
 
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.outsourcing.common.annotation.ResponseMessage;
 import org.example.outsourcing.domain.review.dto.request.ReviewRequestDto;
@@ -22,7 +23,7 @@ public class ReviewController {
 
     @PostMapping
     @ResponseMessage("리뷰가 성공적으로 작성되었습니다.")
-    public ReviewRequestDto createReview(@RequestBody ReviewRequestDto reviewRequestDto) {
+    public ReviewRequestDto createReview(@Valid @RequestBody ReviewRequestDto reviewRequestDto) {
         User user = userRepository.findById(1L)
                 .orElseThrow(() -> new EntityNotFoundException("테스트 유저 없음"));
         reviewService.createReview(user.getId(), reviewRequestDto);

--- a/src/main/java/org/example/outsourcing/domain/review/dto/request/ReviewRequestDto.java
+++ b/src/main/java/org/example/outsourcing/domain/review/dto/request/ReviewRequestDto.java
@@ -1,0 +1,11 @@
+package org.example.outsourcing.domain.review.dto.request;
+
+public record ReviewRequestDto(
+        Long userId,
+        Long orderId,
+        Long storeId,
+        int rating,
+        String content,
+        String reviewImgUrl
+) {
+}

--- a/src/main/java/org/example/outsourcing/domain/review/dto/request/ReviewRequestDto.java
+++ b/src/main/java/org/example/outsourcing/domain/review/dto/request/ReviewRequestDto.java
@@ -1,10 +1,19 @@
 package org.example.outsourcing.domain.review.dto.request;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
 public record ReviewRequestDto(
         Long userId,
         Long orderId,
         Long storeId,
+
+        @Min(value = 1, message = "별점은 최소 1점 이상이어야 합니다.")
+        @Max(value = 5, message = "별점은 최대 5점 이하여야 합니다.")
         int rating,
+
+        @NotBlank(message = "리뷰 내용은 필수입니다.")
         String content,
         String reviewImgUrl
 ) {

--- a/src/main/java/org/example/outsourcing/domain/review/dto/response/ReviewResponseDto.java
+++ b/src/main/java/org/example/outsourcing/domain/review/dto/response/ReviewResponseDto.java
@@ -1,0 +1,10 @@
+package org.example.outsourcing.domain.review.dto.response;
+
+public record ReviewResponseDto(
+        Long reviewId,
+        String customerName,
+        int rating,
+        String content,
+        String reviewImgUrl
+) {}
+

--- a/src/main/java/org/example/outsourcing/domain/review/entity/Review.java
+++ b/src/main/java/org/example/outsourcing/domain/review/entity/Review.java
@@ -1,13 +1,20 @@
 package org.example.outsourcing.domain.review.entity;
 
 import jakarta.persistence.*;
+import lombok.*;
+import org.example.outsourcing.common.base.BaseEntity;
 import org.example.outsourcing.domain.order.entity.Order;
 import org.example.outsourcing.domain.store.entity.Store;
 import org.example.outsourcing.domain.user.entity.User;
 
 
+
 @Entity
-public class Review {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+public class Review extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/example/outsourcing/domain/review/exception/ReviewException.java
+++ b/src/main/java/org/example/outsourcing/domain/review/exception/ReviewException.java
@@ -1,0 +1,17 @@
+package org.example.outsourcing.domain.review.exception;
+
+import lombok.Getter;
+import org.example.outsourcing.common.exception.BaseException;
+import org.example.outsourcing.common.exception.ResponseCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ReviewException extends BaseException {
+    private final ResponseCode responseCode;
+    private final HttpStatus httpStatus;
+
+    public ReviewException(ResponseCode responseCode) {
+        this.responseCode = responseCode;
+        this.httpStatus = responseCode.getStatus();
+    }
+}

--- a/src/main/java/org/example/outsourcing/domain/review/exception/ReviewExceptionCode.java
+++ b/src/main/java/org/example/outsourcing/domain/review/exception/ReviewExceptionCode.java
@@ -1,0 +1,21 @@
+package org.example.outsourcing.domain.review.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.example.outsourcing.common.exception.ResponseCode;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+@RequiredArgsConstructor
+public enum ReviewExceptionCode implements ResponseCode {
+    REVIEW_NOT_FOUND(false, HttpStatus.NOT_FOUND, "리뷰를 찾을 수 없습니다."),
+    ORDER_NOT_FOUND(false, HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다."),
+    USER_NOT_FOUND(false, HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    STORE_NOT_FOUND(false, HttpStatus.NOT_FOUND, "가게를 찾을 수 없습니다."),
+    INVALID_REVIEW_CONDITION(false, HttpStatus.BAD_REQUEST, "배달 완료된 주문만 리뷰를 작성할 수 있습니다.");
+
+    private final boolean isSuccess;
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/org/example/outsourcing/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/org/example/outsourcing/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,35 @@
+package org.example.outsourcing.domain.review.repository;
+
+import org.example.outsourcing.domain.review.dto.response.ReviewResponseDto;
+import org.example.outsourcing.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    @Query("""
+        SELECT new org.example.outsourcing.domain.review.dto.response.ReviewResponseDto(
+            r.id,
+            r.customer.name,
+            r.rating,
+            r.content,
+            r.reviewImgUrl
+        )
+        FROM Review r
+        WHERE r.store.id = :storeId
+          AND r.rating BETWEEN :minRating AND :maxRating
+        ORDER BY r.createdAt DESC
+    """)
+    List<ReviewResponseDto> findReviewListByStoreIdAndRatingBetween(
+            @Param("storeId") Long storeId,
+            @Param("minRating") int minRating,
+            @Param("maxRating") int maxRating
+    );
+
+
+}

--- a/src/main/java/org/example/outsourcing/domain/review/service/ReviewService.java
+++ b/src/main/java/org/example/outsourcing/domain/review/service/ReviewService.java
@@ -1,0 +1,65 @@
+package org.example.outsourcing.domain.review.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.outsourcing.domain.review.dto.response.ReviewResponseDto;
+import org.example.outsourcing.domain.review.exception.ReviewException;
+import org.example.outsourcing.domain.review.exception.ReviewExceptionCode;
+import org.example.outsourcing.domain.user.entity.User;
+import org.example.outsourcing.domain.order.entity.Order;
+import org.example.outsourcing.domain.order.repository.OrderRepository;
+import org.example.outsourcing.domain.review.dto.request.ReviewRequestDto;
+import org.example.outsourcing.domain.review.entity.Review;
+import org.example.outsourcing.domain.review.repository.ReviewRepository;
+import org.example.outsourcing.domain.store.entity.Store;
+import org.example.outsourcing.domain.store.repository.StoreRepository;
+import org.example.outsourcing.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final UserRepository userRepository;
+    private final ReviewRepository reviewRepository;
+    private final OrderRepository orderRepository;
+    private final StoreRepository storeRepository;
+
+    @Transactional
+    public void createReview(Long userId, ReviewRequestDto request) {
+        Order order = orderRepository.findById(request.orderId())
+                .orElseThrow(() -> new ReviewException(ReviewExceptionCode.ORDER_NOT_FOUND));
+        if (!order.getStatus().equals("COMPLETED")) {
+            throw new ReviewException(ReviewExceptionCode.INVALID_REVIEW_CONDITION);
+        }
+
+        User customer = userRepository.findById(userId)
+                .orElseThrow(() -> new ReviewException(ReviewExceptionCode.USER_NOT_FOUND));
+
+
+        Store store = storeRepository.findById(request.storeId())
+                .orElseThrow(() -> new ReviewException(ReviewExceptionCode.STORE_NOT_FOUND));
+
+        Review review = Review.builder()
+                .customer(customer)
+                .order(order)
+                .store(store)
+                .rating(request.rating())
+                .content(request.content())
+                .reviewImgUrl(request.reviewImgUrl())
+                .build();
+
+        reviewRepository.save(review);
+
+    }
+
+    @Transactional(readOnly=true)
+    public List<ReviewResponseDto> getReviewList(Long storeId, int minRating, int maxRating) {
+        return reviewRepository.findReviewListByStoreIdAndRatingBetween(storeId, minRating, maxRating);
+    }
+
+}

--- a/src/main/java/org/example/outsourcing/domain/store/repository/StoreRepository.java
+++ b/src/main/java/org/example/outsourcing/domain/store/repository/StoreRepository.java
@@ -1,0 +1,7 @@
+package org.example.outsourcing.domain.store.repository;
+
+import org.example.outsourcing.domain.store.entity.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+}

--- a/src/main/java/org/example/outsourcing/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/outsourcing/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package org.example.outsourcing.domain.user.repository;
+
+import org.example.outsourcing.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #19

## ✨ 기능 요약
리뷰 생성, 리뷰 다건조회 기능을 구현했습니다.

## 📝 상세 내역
- 리뷰 생성 API 구현 (`POST /api/reviews`)
  - 주문, 상점과 연관된 리뷰 작성 처리
  - 리뷰 내용, 별점, 이미지 URL 등록 가능
  - 현재는 `ReviewRequestDto`에 `userId`와 `orderId` 포함되어 있음
  - 추후 로그인 기능과 합치면서 제외할 예정

- 리뷰 조회 API 구현 (`GET /api/reviews`)
  - 단건 조회 없이, 특정 가게(storeId) 기준으로 다건 조회
  - 별점 범위(minRating ~ maxRating) 필터링 가능
  - 최신순 정렬 적용
  - JPQL 기반 DTO 매핑 (`ReviewResponse` record 사용)
-> API 명세서에서는 storeId를 PathVariable로 받는다고 작성했는데 해당 부분 수정했습니다 ! 참고해주시면 좋을 것 같아요.

## ✅ 테스트 체크리스트
리뷰의 생성 여부를 알기 위해서는 유저와 가게, 주문 정보가 필요해서 해당 부분을 데이터를 임의로 넣어서 구현했습니다. (gpt 시켰어요 ㅎㅎ) 이 데이터 혹시 필요하시다면 가져다가 쓰시면 될 것 같습니다. 
```sql
INSERT INTO user (
  id, email, name, password, is_deleted, profile_img_url, platform
) VALUES (
  1,
  'testuser@example.com',
  '홍길동',
  '$2a$10$encryptedPasswordExample', -- BCrypt 해시
  false,
  'https://cdn.example.com/profiles/testuser.png',
  'GOOGLE'
);

INSERT INTO store (
  id, user_id, name, category, description, address, phone, status,
  created_at, updated_at, min_price, shop_open, shop_close, store_img_url
) VALUES (
  1, 1, '분식천국', '분식', '떡볶이와 튀김 전문점', '서울시 강남구 어디', '010-2222-3333', 'OPEN',
  NOW(), NOW(), 5000, '10:00:00', '22:00:00', 'https://cdn.example.com/images/stores/store_1.jpg'
);


INSERT INTO orders (
  id, user_id, store_id, status, total_price, phone_number, delivery_address
) VALUES (
  1, 1, 1, 'COMPLETED', 12000, '010-1234-5678', '서울시 강남구 어디'
);

```

## 📸 포스트맨 캡처 사진
리뷰 생성하기 API
![image](https://github.com/user-attachments/assets/6c7e0517-894f-4ebe-b7b4-feaf5e706c1c)
![image](https://github.com/user-attachments/assets/6fe5080a-5de1-4a34-a5ea-7a6f31f2ef24)

리뷰 조회하기 API
![image](https://github.com/user-attachments/assets/faec32d5-be53-43ae-b8c3-a4d7ec735083)


## 🙋‍♀️ 리뷰어 참고사항
```java
ORDER_NOT_FOUND(false, HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다."),
    USER_NOT_FOUND(false, HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
    STORE_NOT_FOUND(false, HttpStatus.NOT_FOUND, "가게를 찾을 수 없습니다."),
```
Exception을 각자의 도메인 속에 넣어두고 추후 리팩토링할 때 예외코드를 나누자고 해서 우선은 모든 예외를 `ReviewException`으로 구현했습니다. 하지만 이 부분은 User, Store, Order에서 중복되어 사용되는 부분이고, 책임이 뒤섞이는 구조라고 생각이 되어서 추후에는 전역 예외 코드(ErrorCode)로 분리하여 도메인 책임을 명확히 하고 예외 관리 일관성을 높이는 방향으로 바꾸면 좋겠다는 생각이 듭니다 ... !! 해당 부분에 대해서 어떻게 생각하시는지 의견 주시면 더 좋을 것 같습니다.
++ 추가로 고치거나 개선해야할 점 있으면 리뷰 남겨주세요 !!