### PR TITLE
[feat] 구글 소셜 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'io.jsonwebtoken:jjwt:0.12.6'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/example/outsourcing/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/outsourcing/common/advice/GlobalExceptionHandler.java
@@ -3,34 +3,43 @@ package org.example.outsourcing.common.advice;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.example.outsourcing.common.annotation.ResponseMessage;
 import org.example.outsourcing.common.dto.CommonResponse;
+import org.example.outsourcing.domain.auth.dto.response.TokenResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.validation.FieldError;
-
 
 @Slf4j
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<CommonResponse<Void>> handleMethodArgumentNotValidException(
-            MethodArgumentNotValidException e,
-            HttpServletRequest request
-    ) {
-        log.error("Validation failed: {}", e.getMessage());
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<CommonResponse<Void>> handleMethodArgumentNotValidException(
+		MethodArgumentNotValidException e,
+		HttpServletRequest request
+	) {
+		log.error("Validation failed: {}", e.getMessage());
 
-        String errorMessage = e.getBindingResult().getFieldErrors().stream()
-                .findFirst()
-                .map(FieldError::getDefaultMessage)
-                .orElse("잘못된 요청입니다.");
+		String errorMessage = e.getBindingResult().getFieldErrors().stream()
+			.findFirst()
+			.map(FieldError::getDefaultMessage)
+			.orElse("잘못된 요청입니다.");
 
-        return ResponseEntity
-                .badRequest()
-                .body(CommonResponse.of(false, errorMessage, 400, null));
-    }
+		return ResponseEntity
+			.badRequest()
+			.body(CommonResponse.of(false, errorMessage, 400, null));
+	}
 
+	@ExceptionHandler({AccessDeniedException.class, AuthorizationDeniedException.class})
+	public ResponseEntity<CommonResponse<Void>> handleAccessDenied(Exception ex) {
+		return ResponseEntity.status(HttpStatus.FORBIDDEN).body(CommonResponse.of(false, "접근권한이 없습니다.", 403, null));
+	}
 }

--- a/src/main/java/org/example/outsourcing/common/advice/ResponseWrapping.java
+++ b/src/main/java/org/example/outsourcing/common/advice/ResponseWrapping.java
@@ -26,10 +26,6 @@ public class ResponseWrapping implements ResponseBodyAdvice<Object> {
 		return declaringClass.isAnnotationPresent(RestController.class);
 	}
 
-	/* or 조건으로 @ResponseBody 까지 검사하면 exceptionHandler 도 여기서 랩핑 되서
-	   일단 현재 계획은 ExceptionHandler 는 따로 또 ResponseBodyAdvice 를 만들던지
-	   혹은 exceptionHandler 내부에서 랩핑하던지 하게끔 처리할 예정입니다      */
-
 	@Override
 	public Object beforeBodyWrite(
 		Object body,

--- a/src/main/java/org/example/outsourcing/common/config/SecurityConfig.java
+++ b/src/main/java/org/example/outsourcing/common/config/SecurityConfig.java
@@ -5,10 +5,12 @@ import java.util.List;
 import org.example.outsourcing.common.filter.AccessJwtFilter;
 import org.example.outsourcing.common.filter.ExceptionJwtFilter;
 import org.example.outsourcing.common.filter.RefreshJwtFilter;
+import org.example.outsourcing.common.filter.handler.OauthSuccessHandler;
 import org.example.outsourcing.jwt.service.JwtService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -29,11 +31,13 @@ public class SecurityConfig {
 	private final RefreshJwtFilter refreshJwtFilter;
 	private final AccessJwtFilter accessJwtFilter;
 	private final ExceptionJwtFilter exceptionJwtFilter;
+	private final OauthSuccessHandler successHandler;
 
-	public SecurityConfig(JwtService jwtService) {
+	public SecurityConfig(JwtService jwtService, OauthSuccessHandler successHandler) {
 		this.refreshJwtFilter = new RefreshJwtFilter(jwtService);
 		this.accessJwtFilter = new AccessJwtFilter(jwtService);
 		this.exceptionJwtFilter = new ExceptionJwtFilter();
+		this.successHandler = successHandler;
 	}
 
 	@Bean
@@ -42,6 +46,27 @@ public class SecurityConfig {
 	}
 
 	@Bean
+	@Order(1)
+	public SecurityFilterChain oauth2Chain(HttpSecurity http) throws Exception {
+		http
+			.securityMatcher("/api/auth/oauth2/**")
+			.authorizeHttpRequests(a -> a
+				.anyRequest().authenticated()
+			)
+			.oauth2Login(oauth2 -> oauth2
+				.authorizationEndpoint(ep ->
+					ep.baseUri("/api/auth/oauth2/signin")
+				)
+				.redirectionEndpoint(re ->
+					re.baseUri("/api/auth/oauth2/callback")
+				)
+				.successHandler(successHandler)
+			);
+		return http.build();
+	}
+
+	@Bean
+	@Order(2)
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		return http
 			.cors(cors -> cors.configurationSource(corsConfigurationSource()))
@@ -58,9 +83,6 @@ public class SecurityConfig {
 					"/v2/**",
 					"/v3/**",
 					"/webjars/**"
-				).permitAll()
-				.requestMatchers(HttpMethod.GET,
-					"/api/auth/oauth2/signin/google"
 				).permitAll()
 				.anyRequest().authenticated()
 			)

--- a/src/main/java/org/example/outsourcing/common/config/SecurityConfig.java
+++ b/src/main/java/org/example/outsourcing/common/config/SecurityConfig.java
@@ -7,7 +7,6 @@ import org.example.outsourcing.common.filter.ExceptionJwtFilter;
 import org.example.outsourcing.common.filter.RefreshJwtFilter;
 import org.example.outsourcing.common.filter.handler.OauthSuccessHandler;
 import org.example.outsourcing.jwt.service.JwtService;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -16,6 +15,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -58,11 +59,20 @@ public class SecurityConfig {
 					ep.baseUri("/api/auth/oauth2/signin")
 				)
 				.redirectionEndpoint(re ->
-					re.baseUri("/api/auth/oauth2/callback")
+					re.baseUri("/api/auth/oauth2/callback/*")
 				)
+				.userInfoEndpoint(ui -> ui
+					.userAuthoritiesMapper(grantedAuthoritiesMapper()))
 				.successHandler(successHandler)
 			);
 		return http.build();
+	}
+
+	@Bean
+	public GrantedAuthoritiesMapper grantedAuthoritiesMapper() {
+		return authorities -> List.of(
+			(new SimpleGrantedAuthority("ROLE_social"))
+		);
 	}
 
 	@Bean
@@ -82,7 +92,8 @@ public class SecurityConfig {
 					"/swagger-resources/**",
 					"/v2/**",
 					"/v3/**",
-					"/webjars/**"
+					"/webjars/**",
+					"/api/auth/social/login"
 				).permitAll()
 				.anyRequest().authenticated()
 			)

--- a/src/main/java/org/example/outsourcing/common/config/SwaggerConfig.java
+++ b/src/main/java/org/example/outsourcing/common/config/SwaggerConfig.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.core.jackson.ModelResolver;
 import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
@@ -31,26 +32,25 @@ public class SwaggerConfig {
 		return new OpenAPI()
 			.addSecurityItem(new SecurityRequirement().addList("bearer-key").addList("Refresh-Token"))
 			.components(new Components()
-				.addSecuritySchemes("bearer-key",
-					new SecurityScheme()
-						.type(SecurityScheme.Type.HTTP)
-						.scheme("bearer")
-						.bearerFormat("JWT"))
-				.addSecuritySchemes("Refresh-Token",
-					new SecurityScheme()
-						.type(SecurityScheme.Type.APIKEY)
-						.in(SecurityScheme.In.HEADER)
-						.name("Refresh-Token")
-						.description("Bearer 를 붙여서 넣어주어야 합니다."
-							+ "ex) Bearer xxxxxx")))
-			.info(apiInfo());
-	}
-
-	private Info apiInfo() {
-		return new Info()
-			.title("out-sourcing")
-			.description("과제의 민족 팀 프로젝트 과제")
-			.version("1.0");
+				.addSecuritySchemes("bearer-key", new SecurityScheme()
+					.type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT"))
+				.addSecuritySchemes("Refresh-Token", new SecurityScheme()
+					.type(SecurityScheme.Type.APIKEY).in(SecurityScheme.In.HEADER)
+					.name("Refresh-Token")
+					.description("Bearer 를 붙여서 넣어주어야 합니다. ex) Bearer xxxxxx"))
+			)
+			.info(new Info()
+				.title("out-sourcing")
+				.version("1.0")
+				.description(
+					"과제의 민족 팀 프로젝트 과제  \n" +
+						"[▶ Google OAuth2 로그인](http://localhost:8080/api/auth/oauth2/signin/google)"
+				)
+			)
+			.externalDocs(new ExternalDocumentation()
+				.description("Google Sign-in 바로가기")
+				.url("http://localhost:8080/api/auth/oauth2/signin/google")
+			);
 	}
 }
 

--- a/src/main/java/org/example/outsourcing/common/filter/AccessJwtFilter.java
+++ b/src/main/java/org/example/outsourcing/common/filter/AccessJwtFilter.java
@@ -23,8 +23,6 @@ public class AccessJwtFilter extends BaseJwtFilter {
 			|| uri.equals(FilterConstants.REISSUE);
 	}
 
-	//튜터님 조언으로 /api/users 하나로 생성 삭제를 둘다 수행하기 때문에 method 가 DELETE 일때는 인증을 SKIP 하지 않게끔 조치했습니다.
-
 	@Override
 	protected String getTokenFromRequest(HttpServletRequest request) {
 		return request.getHeader(JwtConstants.AUTH_HEADER);

--- a/src/main/java/org/example/outsourcing/common/filter/BaseJwtFilter.java
+++ b/src/main/java/org/example/outsourcing/common/filter/BaseJwtFilter.java
@@ -47,7 +47,6 @@ public abstract class BaseJwtFilter extends OncePerRequestFilter {
 		if (jwtService.isBlackListed(token) && shouldCheckBlackList()) {
 			throw new FilterException(FilterExceptionCode.CANT_USE_TOKEN);
 		}
-		// 로그아웃한 토큰은 이제 재사용이 안되게끔 처리했습니다
 
 		if (jwtService.isTokenExpired(token)) {
 			throw new FilterException(FilterExceptionCode.TOKEN_EXPIRED);

--- a/src/main/java/org/example/outsourcing/common/filter/constants/FilterConstants.java
+++ b/src/main/java/org/example/outsourcing/common/filter/constants/FilterConstants.java
@@ -16,7 +16,8 @@ public class FilterConstants {
 		"/swagger-ui",
 		"/v3/api-docs",
 		"/swagger-resources",
-		"/webjars"
+		"/webjars",
+		"/api/auth/social/login"
 	);
 
 	public static final String REISSUE = "/api/auth/reissue";

--- a/src/main/java/org/example/outsourcing/common/filter/handler/OauthSuccessHandler.java
+++ b/src/main/java/org/example/outsourcing/common/filter/handler/OauthSuccessHandler.java
@@ -1,0 +1,33 @@
+package org.example.outsourcing.common.filter.handler;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+@Component
+public class OauthSuccessHandler implements AuthenticationSuccessHandler {
+
+	@Override
+	public void onAuthenticationSuccess(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		Authentication authentication
+	) throws IOException, ServletException {
+
+		if (authentication instanceof OAuth2AuthenticationToken oauthToken) {
+			OAuth2User oauthUser = oauthToken.getPrincipal();
+			HttpSession session = request.getSession();
+			session.invalidate();
+
+		}
+	}
+}

--- a/src/main/java/org/example/outsourcing/common/filter/handler/OauthSuccessHandler.java
+++ b/src/main/java/org/example/outsourcing/common/filter/handler/OauthSuccessHandler.java
@@ -2,7 +2,10 @@ package org.example.outsourcing.common.filter.handler;
 
 import java.io.IOException;
 
+import org.example.outsourcing.domain.auth.dto.UserAuth;
+import org.example.outsourcing.domain.user.entity.User;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
@@ -23,11 +26,10 @@ public class OauthSuccessHandler implements AuthenticationSuccessHandler {
 		Authentication authentication
 	) throws IOException, ServletException {
 
-		if (authentication instanceof OAuth2AuthenticationToken oauthToken) {
-			OAuth2User oauthUser = oauthToken.getPrincipal();
-			HttpSession session = request.getSession();
-			session.invalidate();
+		HttpSession session = request.getSession();
+		session.invalidate();
 
-		}
+		request.getRequestDispatcher("/api/auth/social/login")
+			.forward(request, response);
 	}
 }

--- a/src/main/java/org/example/outsourcing/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/example/outsourcing/domain/auth/controller/AuthController.java
@@ -6,9 +6,14 @@ import org.example.outsourcing.domain.auth.dto.response.TokenResponse;
 import org.example.outsourcing.domain.auth.dto.request.loginRequest;
 import org.example.outsourcing.domain.auth.service.AuthService;
 import org.example.outsourcing.common.util.SecurityUtils;
+import org.example.outsourcing.domain.user.dto.response.UserResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -48,6 +53,13 @@ public class AuthController {
 	@PostMapping("/reissue")
 	public ResponseEntity<TokenResponse> reissue(@AuthenticationPrincipal UserAuth userAuth) {
 		return ResponseEntity.ok(authService.reissue(userAuth, SecurityUtils.getCurrentToken()));
+	}
+
+	@Operation(hidden = true)
+	@PreAuthorize("hasRole('social')")
+	@GetMapping("/social/login")
+	public ResponseEntity<TokenResponse> socialSignIn(@AuthenticationPrincipal OAuth2User oAuth) {
+		return ResponseEntity.status(HttpStatus.CREATED).body(authService.socialSignIn(oAuth));
 	}
 
 }

--- a/src/main/java/org/example/outsourcing/domain/auth/service/AuthService.java
+++ b/src/main/java/org/example/outsourcing/domain/auth/service/AuthService.java
@@ -1,16 +1,21 @@
 package org.example.outsourcing.domain.auth.service;
 
 import java.util.Date;
+import java.util.List;
+import java.util.UUID;
 
 import org.example.outsourcing.domain.auth.dto.response.TokenResponse;
 import org.example.outsourcing.domain.auth.dto.UserAuth;
 import org.example.outsourcing.domain.auth.dto.request.loginRequest;
+import org.example.outsourcing.domain.user.entity.Platform;
 import org.example.outsourcing.domain.user.entity.User;
+import org.example.outsourcing.domain.user.entity.UserRole;
 import org.example.outsourcing.domain.user.exception.UserException;
 import org.example.outsourcing.domain.user.exception.UserExceptionCode;
 import org.example.outsourcing.domain.user.repository.UserRepository;
 import org.example.outsourcing.jwt.service.JwtService;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
 import jakarta.transaction.Transactional;
@@ -27,12 +32,40 @@ public class AuthService {
 	@Transactional
 	public TokenResponse sighIn(loginRequest request) {
 
-		User user = userRepository.findByEmailAndIsDeleted(request.email(), false)
+		User user = userRepository.findByEmailAndPlatformAndIsDeleted(request.email(), Platform.LOCAL, false)
 			.orElseThrow(() -> new UserException(UserExceptionCode.USER_NOT_FOUND));
 
 		checkPassword(request.password(), user.getPassword());
 
 		return jwtService.generateToken(UserAuth.from(user), new Date());
+	}
+
+	@Transactional
+	public TokenResponse socialSignIn(OAuth2User oAuth) {
+		String email = oAuth.getAttribute("email");
+		String name = oAuth.getAttribute("name");
+
+		return userRepository.findByEmailAndPlatformAndIsDeleted(email, Platform.GOOGLE, false)
+			.map(user -> jwtService.generateToken(
+					UserAuth.from(user),
+					new Date()
+				)
+			)
+			.orElseGet(() -> {
+				User user = userRepository.save(
+					User.builder()
+						.email(email)
+						.name(name)
+						.roles(List.of(UserRole.SOCIAL.getRole(), UserRole.USER.getRole()))
+						.password(UUID.randomUUID().toString())
+						.platform(Platform.GOOGLE)
+						.build()
+				);
+				return jwtService.generateToken(
+					UserAuth.from(user),
+					new Date()
+				);
+			});
 	}
 
 	public void sighOut(String accessToken) {

--- a/src/main/java/org/example/outsourcing/domain/user/controller/UserController.java
+++ b/src/main/java/org/example/outsourcing/domain/user/controller/UserController.java
@@ -45,5 +45,4 @@ public class UserController {
 		return ResponseEntity.ok().build();
 	}
 
-	//컨트롤러에
 }

--- a/src/main/java/org/example/outsourcing/domain/user/entity/Platform.java
+++ b/src/main/java/org/example/outsourcing/domain/user/entity/Platform.java
@@ -1,6 +1,6 @@
 package org.example.outsourcing.domain.user.entity;
 
 public enum Platform {
-	GOOGLE, KAKAO, NAVER, LOCAL
+	GOOGLE, LOCAL
 }
 

--- a/src/main/java/org/example/outsourcing/domain/user/entity/User.java
+++ b/src/main/java/org/example/outsourcing/domain/user/entity/User.java
@@ -15,24 +15,30 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "user")
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
+@Table(
+	name = "user",
+	uniqueConstraints = {
+		@UniqueConstraint(columnNames = {"email", "platform"})
+	}
+)
 public class User extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(unique = true, nullable = false)
+	@Column(nullable = false)
 	private String email;
 
 	@Column

--- a/src/main/java/org/example/outsourcing/domain/user/entity/UserRole.java
+++ b/src/main/java/org/example/outsourcing/domain/user/entity/UserRole.java
@@ -11,7 +11,8 @@ public enum UserRole {
 
 	ADMIN("ROLE_admin", "admin"::equals),
 	USER("ROLE_user", "user"::equals),
-	OWNER("ROLE_owner", "owner"::equals);
+	OWNER("ROLE_owner", "owner"::equals),
+	SOCIAL("ROLE_social", "social"::equals);
 
 	private final String role;
 	private final Predicate<String> func;

--- a/src/main/java/org/example/outsourcing/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/outsourcing/domain/user/repository/UserRepository.java
@@ -2,14 +2,14 @@ package org.example.outsourcing.domain.user.repository;
 
 import java.util.Optional;
 
+import org.example.outsourcing.domain.user.entity.Platform;
 import org.example.outsourcing.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-	boolean existsByEmail(String email);
+	boolean existsByEmailAndPlatform(String email, Platform platform);
 
-	Optional<User> findByEmailAndIsDeleted(String email, boolean isDeleted);
-
+	Optional<User> findByEmailAndPlatformAndIsDeleted(String email, Platform platform, boolean isDeleted);
 }
 

--- a/src/main/java/org/example/outsourcing/domain/user/service/UserService.java
+++ b/src/main/java/org/example/outsourcing/domain/user/service/UserService.java
@@ -55,7 +55,7 @@ public class UserService {
 	@Transactional
 	public void withDrawUser(UserDeleteRequest request, String accessToken) {
 
-		User user = userRepository.findByEmailAndIsDeleted(request.email(), false)
+		User user = userRepository.findByEmailAndPlatformAndIsDeleted(request.email(), Platform.LOCAL, false)
 			.orElseThrow(() -> new UserException(UserExceptionCode.USER_NOT_FOUND));
 
 		checkPassword(request.password(), user.getPassword());
@@ -69,7 +69,7 @@ public class UserService {
 
 	private void checkEmail(String email) {
 
-		if (userRepository.existsByEmail(email)) {
+		if (userRepository.existsByEmailAndPlatform(email, Platform.LOCAL)) {
 			throw new UserException(UserExceptionCode.ALREADY_EXISTS_EMAIL);
 		}
 	}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #37  <!-- 연결된 이슈 번호 기재 -->



## ✨ 기능 요약

구글 소셜 로그인 기능이 구현되어있습니다.

<!--
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | 기능 이름을 간단히 요약 |
| 🔍 목적 | 해당 기능이 왜 필요한지 간략 설명 |
| 🛠️ 변경사항 | 핵심 변경 포인트 간략히 요약 (예: UI 추가, API 연동 등) |
--> 


## 📝 상세 내역
![image](https://github.com/user-attachments/assets/392eca34-14ee-401d-afe2-06a9c0b9ad41)

Oauth2 인증을 받을때 세션 생성이 반드시 필요하여 기존의 Jwt 필터체인에 통합시킬 수가 없어서 체인을 하나 더 생성했습니다. 세션은 인증 성공 후에 successHandler가 바로 파기합니다.


![image](https://github.com/user-attachments/assets/8bec2432-881b-4dbc-af51-413d314c4b81)

소셜 로그인이 완료되면 사용자는 ROLE_social 이란 권한을 부여받습니다.
해당 권한은 소셜 로그인 컨트롤러에 접근할 때 권한을 검증받습니다.(소셜 로그인 사용자만 접근이 가능합니다) 

![image](https://github.com/user-attachments/assets/5cb985fc-77b5-4e8a-a229-cb7da12bc264)

로그인 시 비밀번호 검증은 없고 계정이 존재하면 로그인 처리가 되며 만약에 계정이 없을 시에는 즉석으로 생성해서
토큰을 발급합니다. 발급 된 토큰에는 user, social 권한이 부여되니 적절하게 사용하시면 될 듯 합니다.

![image](https://github.com/user-attachments/assets/91ffeaf6-32a8-4ad0-80f4-479e2870926a)

기존 유저 엔티티의 경우, 소셜 로그인 시에 로컬 사용자 이메일과 중복될 경우, 가입이 안되었는데
이 부분을 개선하고자 이메일과 플랫폼을 복합으로 유니크 제약을 주었습니다.
때문에 이메일이 중복되더라도 플랫폼만 다르면 가입이 가능합니다. 



<!--
| 번호 | 내용 |
|------|------|
| 1️⃣ | 주요 로직/컴포넌트/서비스 등 변경 설명 |
| 2️⃣ | 관련 유틸, 공통 로직 수정 여부 |
| 3️⃣ | 리팩토링 또는 제거된 불필요 코드 |
--> 


## ✅ 테스트 체크리스트
<!-- 테스트 할 내용이 있다면 작성해주세요
- [ ] 기능 정상 작동 확인
- [ ] 예외/엣지 케이스 확인
- [ ] UI/UX 흐름 확인 (필요 시 캡처 또는 영상 첨부)
- [ ] 테스트 코드 작성 완료
- [ ] API 연동 확인 (요청/응답 정상 동작)
--> 


## 📸 포스트맨 캡처 사진


## 🙋‍♀️ 리뷰어 참고사항
![Honeycam 2025-04-24 21-19-30](https://github.com/user-attachments/assets/edd9d6b5-3656-49aa-926e-0196584ee30a)
swagger 에서 구글 로그인 방법입니다.


<!-- 
- 테스트 방법
- 주요 로직 설명
- 리뷰 시 중점적으로 봐주셨으면 하는 부분
- 코드 스타일 관련 사항 등
--> 
