### PR TITLE
[feat] 회원삭제 , 변경, 인가 기능 추가#46

### DIFF
--- a/src/main/java/org/example/outsourcing/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/outsourcing/common/advice/GlobalExceptionHandler.java
@@ -1,12 +1,12 @@
 package org.example.outsourcing.common.advice;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.example.outsourcing.common.annotation.ResponseMessage;
 import org.example.outsourcing.common.dto.CommonResponse;
-import org.example.outsourcing.domain.auth.dto.response.TokenResponse;
+import org.example.outsourcing.common.exception.BaseException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -38,8 +38,24 @@ public class GlobalExceptionHandler {
 			.body(CommonResponse.of(false, errorMessage, 400, null));
 	}
 
+	@ExceptionHandler(BaseException.class)
+	public ResponseEntity<CommonResponse<Void>> handleBaseException(
+		BaseException e
+	) {
+		return ResponseEntity.status(e.getHttpStatus()).body(CommonResponse.from(e.getResponseCode()));
+	}
+
 	@ExceptionHandler({AccessDeniedException.class, AuthorizationDeniedException.class})
-	public ResponseEntity<CommonResponse<Void>> handleAccessDenied(Exception ex) {
-		return ResponseEntity.status(HttpStatus.FORBIDDEN).body(CommonResponse.of(false, "접근권한이 없습니다.", 403, null));
+	public ResponseEntity<CommonResponse<Void>> handleAccessDeniedException(Exception ex) {
+		return ResponseEntity
+			.status(HttpStatus.FORBIDDEN)
+			.body(
+				CommonResponse.of(
+					false,
+					"접근권한이 없습니다.",
+					HttpServletResponse.SC_FORBIDDEN,
+					null
+				)
+			);
 	}
 }

--- a/src/main/java/org/example/outsourcing/common/config/SecurityConfig.java
+++ b/src/main/java/org/example/outsourcing/common/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.example.outsourcing.common.filter.AccessJwtFilter;
 import org.example.outsourcing.common.filter.ExceptionJwtFilter;
 import org.example.outsourcing.common.filter.RefreshJwtFilter;
+import org.example.outsourcing.common.filter.handler.OauthFailureHandler;
 import org.example.outsourcing.common.filter.handler.OauthSuccessHandler;
 import org.example.outsourcing.jwt.service.JwtService;
 import org.springframework.context.annotation.Bean;
@@ -33,12 +34,14 @@ public class SecurityConfig {
 	private final AccessJwtFilter accessJwtFilter;
 	private final ExceptionJwtFilter exceptionJwtFilter;
 	private final OauthSuccessHandler successHandler;
+	private final OauthFailureHandler failureHandler;
 
-	public SecurityConfig(JwtService jwtService, OauthSuccessHandler successHandler) {
+	public SecurityConfig(JwtService jwtService, OauthSuccessHandler successHandler, OauthFailureHandler failureHandler) {
 		this.refreshJwtFilter = new RefreshJwtFilter(jwtService);
 		this.accessJwtFilter = new AccessJwtFilter(jwtService);
 		this.exceptionJwtFilter = new ExceptionJwtFilter();
 		this.successHandler = successHandler;
+		this.failureHandler = failureHandler;
 	}
 
 	@Bean
@@ -64,6 +67,7 @@ public class SecurityConfig {
 				.userInfoEndpoint(ui -> ui
 					.userAuthoritiesMapper(grantedAuthoritiesMapper()))
 				.successHandler(successHandler)
+				.failureHandler(failureHandler)
 			);
 		return http.build();
 	}

--- a/src/main/java/org/example/outsourcing/common/filter/AccessJwtFilter.java
+++ b/src/main/java/org/example/outsourcing/common/filter/AccessJwtFilter.java
@@ -18,9 +18,9 @@ public class AccessJwtFilter extends BaseJwtFilter {
 		String method = request.getMethod();
 
 		return (FilterConstants.WHITE_LIST.stream()
-			.anyMatch(uri::contains)
-			&& !method.equals("DELETE"))
-			|| uri.equals(FilterConstants.REISSUE);
+			.anyMatch(uri::contains))
+			|| (uri.equals(FilterConstants.USER_CRUD) && method.equals("POST"))
+			|| (uri.equals(FilterConstants.REISSUE));
 	}
 
 	@Override

--- a/src/main/java/org/example/outsourcing/common/filter/ExceptionJwtFilter.java
+++ b/src/main/java/org/example/outsourcing/common/filter/ExceptionJwtFilter.java
@@ -1,9 +1,11 @@
 package org.example.outsourcing.common.filter;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.example.outsourcing.common.dto.CommonResponse;
 import org.example.outsourcing.common.filter.exception.FilterException;
+import org.springframework.http.MediaType;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,8 +30,9 @@ public class ExceptionJwtFilter extends OncePerRequestFilter {
 			filterChain.doFilter(request, response);
 		} catch (FilterException filterException) {
 			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-			response.setContentType("application/json");
-			response.setCharacterEncoding("UTF-8");
+			response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+			response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
 			objectMapper.writeValue(
 				response.getWriter(),
 				CommonResponse.from(filterException.getResponseCode())

--- a/src/main/java/org/example/outsourcing/common/filter/constants/FilterConstants.java
+++ b/src/main/java/org/example/outsourcing/common/filter/constants/FilterConstants.java
@@ -10,7 +10,6 @@ public class FilterConstants {
 
 	public static final List<String> WHITE_LIST = List.of(
 		"/api/auth/signin",
-		"/api/users",
 		"/api/auth/oauth2/signin/google",
 		"/resources",
 		"/swagger-ui",
@@ -19,6 +18,8 @@ public class FilterConstants {
 		"/webjars",
 		"/api/auth/social/login"
 	);
+
+	public static final String USER_CRUD = "/api/users";
 
 	public static final String REISSUE = "/api/auth/reissue";
 }

--- a/src/main/java/org/example/outsourcing/common/filter/handler/OauthFailureHandler.java
+++ b/src/main/java/org/example/outsourcing/common/filter/handler/OauthFailureHandler.java
@@ -1,0 +1,55 @@
+package org.example.outsourcing.common.filter.handler;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.example.outsourcing.common.dto.CommonResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OauthFailureHandler implements AuthenticationFailureHandler {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void onAuthenticationFailure(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		AuthenticationException exception
+	) throws IOException, ServletException {
+
+		HttpSession session = request.getSession(false);
+		if (session != null) {
+			session.invalidate();
+		}
+
+		SecurityContextHolder.clearContext();
+
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+		objectMapper.writeValue(
+			response.getWriter(),
+			CommonResponse.of(
+				false,
+				"로그인에 실패했습니다. 잠시 후 다시 시도해주세요.",
+				HttpServletResponse.SC_UNAUTHORIZED,
+				null
+			)
+		);
+	}
+}

--- a/src/main/java/org/example/outsourcing/common/filter/handler/OauthSuccessHandler.java
+++ b/src/main/java/org/example/outsourcing/common/filter/handler/OauthSuccessHandler.java
@@ -2,12 +2,7 @@ package org.example.outsourcing.common.filter.handler;
 
 import java.io.IOException;
 
-import org.example.outsourcing.domain.auth.dto.UserAuth;
-import org.example.outsourcing.domain.user.entity.User;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
@@ -26,8 +21,10 @@ public class OauthSuccessHandler implements AuthenticationSuccessHandler {
 		Authentication authentication
 	) throws IOException, ServletException {
 
-		HttpSession session = request.getSession();
-		session.invalidate();
+		HttpSession session = request.getSession(false);
+		if (session != null) {
+			session.invalidate();
+		}
 
 		request.getRequestDispatcher("/api/auth/social/login")
 			.forward(request, response);

--- a/src/main/java/org/example/outsourcing/common/util/SecurityUtils.java
+++ b/src/main/java/org/example/outsourcing/common/util/SecurityUtils.java
@@ -11,6 +11,4 @@ public class SecurityUtils {
 	}
 }
 
-//auth user 도메인 등 여러곳에서 참조되어 common 하위로 이동시켰습니다
-
 

--- a/src/main/java/org/example/outsourcing/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/example/outsourcing/domain/auth/controller/AuthController.java
@@ -6,7 +6,6 @@ import org.example.outsourcing.domain.auth.dto.response.TokenResponse;
 import org.example.outsourcing.domain.auth.dto.request.loginRequest;
 import org.example.outsourcing.domain.auth.service.AuthService;
 import org.example.outsourcing.common.util.SecurityUtils;
-import org.example.outsourcing.domain.user.dto.response.UserResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -33,7 +32,7 @@ public class AuthController {
 
 	@Operation(summary = "로그인")
 	@SecurityRequirements({})
-	@ResponseMessage("정상적으로 로그인이이 되었습니다.")
+	@ResponseMessage("정상적으로 로그인이 되었습니다.")
 	@PostMapping("/signin")
 	public ResponseEntity<TokenResponse> singIn(@RequestBody @Validated loginRequest request) {
 		return ResponseEntity.ok(authService.sighIn(request));
@@ -56,7 +55,8 @@ public class AuthController {
 	}
 
 	@Operation(hidden = true)
-	@PreAuthorize("hasRole('social')")
+	@PreAuthorize("@auth.requiredSocial(authentication.getAuthorities())")
+	@ResponseMessage("정상적으로 소셜 로그인이 되었습니다.")
 	@GetMapping("/social/login")
 	public ResponseEntity<TokenResponse> socialSignIn(@AuthenticationPrincipal OAuth2User oAuth) {
 		return ResponseEntity.status(HttpStatus.CREATED).body(authService.socialSignIn(oAuth));

--- a/src/main/java/org/example/outsourcing/domain/auth/exception/AuthException.java
+++ b/src/main/java/org/example/outsourcing/domain/auth/exception/AuthException.java
@@ -1,0 +1,18 @@
+package org.example.outsourcing.domain.auth.exception;
+
+import org.example.outsourcing.common.exception.BaseException;
+import org.example.outsourcing.common.exception.ResponseCode;
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public class AuthException extends BaseException {
+  private final ResponseCode responseCode;
+  private final HttpStatus httpStatus;
+
+  public AuthException(ResponseCode responseCode) {
+    this.responseCode = responseCode;
+    this.httpStatus = responseCode.getStatus();
+  }
+}

--- a/src/main/java/org/example/outsourcing/domain/auth/exception/AuthExceptionCode.java
+++ b/src/main/java/org/example/outsourcing/domain/auth/exception/AuthExceptionCode.java
@@ -1,0 +1,18 @@
+package org.example.outsourcing.domain.auth.exception;
+
+import org.example.outsourcing.common.exception.ResponseCode;
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthExceptionCode implements ResponseCode {
+
+	SOCIAL_LOGIN_REQUIRED(false, HttpStatus.FORBIDDEN, "먼저 소셜 로그인 인증부터 진행해야합니다.");
+
+	private final boolean isSuccess;
+	private final HttpStatus status;
+	private final String message;
+}

--- a/src/main/java/org/example/outsourcing/domain/auth/exception/UserAuthorizationService.java
+++ b/src/main/java/org/example/outsourcing/domain/auth/exception/UserAuthorizationService.java
@@ -1,0 +1,23 @@
+package org.example.outsourcing.domain.auth.exception;
+
+import java.util.Collection;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
+
+@Component("auth")
+public class UserAuthorizationService {
+
+	public boolean requiredSocial(Collection<? extends GrantedAuthority> roles) {
+
+		boolean has = roles.stream()
+			.map(GrantedAuthority::getAuthority)
+			.anyMatch(role -> role.equals("ROLE_social"));
+
+		if (!has) {
+			throw new AuthException(AuthExceptionCode.SOCIAL_LOGIN_REQUIRED);
+		}
+		return true;
+	}
+
+}

--- a/src/main/java/org/example/outsourcing/domain/user/controller/UserController.java
+++ b/src/main/java/org/example/outsourcing/domain/user/controller/UserController.java
@@ -2,15 +2,20 @@ package org.example.outsourcing.domain.user.controller;
 
 import org.example.outsourcing.common.annotation.ResponseMessage;
 import org.example.outsourcing.common.util.SecurityUtils;
+import org.example.outsourcing.domain.auth.dto.UserAuth;
 import org.example.outsourcing.domain.user.dto.request.UserDeleteRequest;
+import org.example.outsourcing.domain.user.dto.request.UserModifyRequest;
 import org.example.outsourcing.domain.user.dto.response.UserResponse;
 import org.example.outsourcing.domain.user.dto.request.UserSaveRequest;
 import org.example.outsourcing.domain.user.service.UserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,17 +37,38 @@ public class UserController {
 	@SecurityRequirements({})
 	@PostMapping
 	@ResponseMessage("정상적으로 가입처리 되었습니다.")
-	public ResponseEntity<UserResponse> createUser(@RequestBody @Validated UserSaveRequest request) {
-		return ResponseEntity.status(HttpStatus.CREATED).body(userService.createUser(request));
+	public ResponseEntity<Void> createUser(
+		@RequestBody @Validated UserSaveRequest request) {
+		userService.createUser(request);
+		return ResponseEntity.status(HttpStatus.CREATED).build();
 	}
 
+	@PreAuthorize("@userz.checkUserId(authentication.principal.id, #request.email())")
 	@Operation(summary = "회원탈퇴", security = {@SecurityRequirement(name = "bearer-key")})
 	@DeleteMapping
 	@ResponseMessage("정상적으로 탈퇴처리 되었습니다.")
-	public ResponseEntity<Void> withDrawUser(@RequestBody @Validated UserDeleteRequest request) {
+	public ResponseEntity<Void> withDrawUser(
+		@RequestBody @Validated UserDeleteRequest request) {
 		userService.withDrawUser(request, SecurityUtils.getCurrentToken());
 		SecurityUtils.clearContext();
 		return ResponseEntity.ok().build();
 	}
 
+	@PreAuthorize("hasAnyRole('user','admin','owner') and @userz.checkUserId(authentication.principal.id, #request.email())")
+	@Operation(summary = "회원정보수정", security = {@SecurityRequirement(name = "bearer-key")})
+	@PatchMapping
+	@ResponseMessage("정상적으로 수정되었습니다.")
+	public ResponseEntity<Void> modifyUser(
+		@RequestBody @Validated UserModifyRequest request) {
+		userService.modifyUser(request);
+		return ResponseEntity.ok().build();
+	}
+
+	@Operation(summary = "회원정보조회", security = {@SecurityRequirement(name = "bearer-key")})
+	@GetMapping
+	@ResponseMessage("정상적으로 조회되었습니다.")
+	public ResponseEntity<UserResponse> viewUser(
+		@AuthenticationPrincipal UserAuth userAuth) {
+		return ResponseEntity.ok(userService.viewUser(userAuth));
+	}
 }

--- a/src/main/java/org/example/outsourcing/domain/user/dto/request/UserDeleteRequest.java
+++ b/src/main/java/org/example/outsourcing/domain/user/dto/request/UserDeleteRequest.java
@@ -8,10 +8,14 @@ public record UserDeleteRequest(
 	@NotBlank
 	@Schema(description = "삭제 대상자의 email")
 	String email,
-	@NotBlank
+
 	@Schema(description = "삭제 대상자의 비밀번호")
 	String password
 
 ) {
+	public UserDeleteRequest {
+		if(password == null) {
+			password = "default";
+		}
+	}
 }
-

--- a/src/main/java/org/example/outsourcing/domain/user/dto/request/UserModifyRequest.java
+++ b/src/main/java/org/example/outsourcing/domain/user/dto/request/UserModifyRequest.java
@@ -1,0 +1,32 @@
+package org.example.outsourcing.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UserModifyRequest(
+
+	@NotBlank
+	@Schema(description = "변경 대상자의 email")
+	String email,
+
+	@NotBlank
+	@Schema(description = "변경 대상자의 기존 비밀번호")
+	String password,
+
+	@NotBlank(message = "변경하실 이름을 입력해주세요.")
+	@Size(max = 20, message = "이름 최대 20글자가 넘지 않도록 해주십시오.")
+	@Schema(description = "변경할 이름")
+	String name,
+
+	@NotBlank(message = "비밀번호는 필수 입력값입니다.")
+	@Pattern(
+		regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()\\-_=+{};:,<.>]).{8,}$",
+		message = "비밀번호는 최소 8자 이상이며, 대문자, 소문자, 숫자, 특수문자를 모두 포함해야 합니다"
+	)
+	@Schema(description = "변경할 비밀번호(최소 8자 이상, 대문자, 소문자, 숫자, 특수문자를 모두 포함)")
+	String newPassword
+
+) {
+}

--- a/src/main/java/org/example/outsourcing/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/org/example/outsourcing/domain/user/dto/response/UserResponse.java
@@ -2,6 +2,7 @@ package org.example.outsourcing.domain.user.dto.response;
 
 import java.time.LocalDateTime;
 
+import org.example.outsourcing.domain.user.entity.Platform;
 import org.example.outsourcing.domain.user.entity.User;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -10,16 +11,25 @@ import lombok.Builder;
 @Builder
 public record UserResponse(
 
-	@Schema(description = "계정 생성자의 email")
+	@Schema(description = "계정 email")
 	String email,
+
+	@Schema(description = "이름")
+	String name,
+
 	@Schema(description = "계정 생성 일자")
-	LocalDateTime createdAt
+	LocalDateTime createdAt,
+
+	@Schema(description = "사용중인 플랫폼")
+	Platform platform
 
 ) {
 	public static UserResponse from(User user) {
 		return UserResponse.builder()
 			.email(user.getEmail())
 			.createdAt(user.getCreatedAt())
+			.name(user.getName())
+			.platform(user.getPlatform())
 			.build();
 	}
 }

--- a/src/main/java/org/example/outsourcing/domain/user/entity/User.java
+++ b/src/main/java/org/example/outsourcing/domain/user/entity/User.java
@@ -61,13 +61,16 @@ public class User extends BaseEntity {
 	private Platform platform;
 
 	public void withdraw() {
+		if (Platform.LOCAL != platform) {
+			this.email = "deleted email" + UUID.randomUUID() + "@unknown";
+		}
 		this.name = "deleted user" + UUID.randomUUID();
 		this.isDeleted = true;
 		this.roles.clear();
 	}
 
-	public void changePassword(String newPassword) {
+	public void changeProfileInformation(String name, String newPassword) {
+		this.name = name;
 		this.password = newPassword;
 	}
-
 }

--- a/src/main/java/org/example/outsourcing/domain/user/exception/UserCrudAuthorizationService.java
+++ b/src/main/java/org/example/outsourcing/domain/user/exception/UserCrudAuthorizationService.java
@@ -1,0 +1,29 @@
+package org.example.outsourcing.domain.user.exception;
+
+import java.util.Objects;
+
+import org.example.outsourcing.domain.user.entity.User;
+import org.example.outsourcing.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component("userz")
+@RequiredArgsConstructor
+public class UserCrudAuthorizationService {
+
+	private final UserRepository userRepository;
+
+	public boolean checkUserId(Long userId, String email) {
+
+		User user = userRepository.findByEmailAndIsDeleted(email, false)
+			.orElseThrow(() -> new UserException(UserExceptionCode.USER_NOT_FOUND));
+
+		if (!Objects.equals(userId, user.getId())) {
+			throw new UserException(UserExceptionCode.NOT_OWNED_ID);
+		}
+
+		return true;
+	}
+
+}

--- a/src/main/java/org/example/outsourcing/domain/user/exception/UserExceptionCode.java
+++ b/src/main/java/org/example/outsourcing/domain/user/exception/UserExceptionCode.java
@@ -11,10 +11,9 @@ import lombok.RequiredArgsConstructor;
 public enum UserExceptionCode implements ResponseCode {
 
 	WRONG_PASSWORD(false, HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸습니다."),
-	SAME_PASSWORD(false, HttpStatus.CONFLICT, "기존과 동일한 비밀번호로 수정할 수 없습니다."),
-	NOT_CHANGED(false, HttpStatus.BAD_REQUEST, "수정 사항이 존재하지 않습니다."),
+	NOT_OWNED_ID(false, HttpStatus.FORBIDDEN, "현재 로그인한 계정의 이메일을 입력하십시오."),
 	USER_NOT_FOUND(false, HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
-	ALREADY_EXISTS_EMAIL(false, HttpStatus.CONFLICT, "이미 존재하는 이메일이 있습니다.");
+	ALREADY_EXISTS_EMAIL(false, HttpStatus.CONFLICT, "이미 존재하는 이메일이 있습니다;.");
 
 	private final boolean isSuccess;
 	private final HttpStatus status;

--- a/src/main/java/org/example/outsourcing/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/outsourcing/domain/user/repository/UserRepository.java
@@ -11,5 +11,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	boolean existsByEmailAndPlatform(String email, Platform platform);
 
 	Optional<User> findByEmailAndPlatformAndIsDeleted(String email, Platform platform, boolean isDeleted);
+
+	Optional<User> findByEmailAndIsDeleted(String email, boolean isDeleted);
 }
 

--- a/src/main/java/org/example/outsourcing/domain/user/service/UserService.java
+++ b/src/main/java/org/example/outsourcing/domain/user/service/UserService.java
@@ -2,7 +2,9 @@ package org.example.outsourcing.domain.user.service;
 
 import java.util.Arrays;
 
+import org.example.outsourcing.domain.auth.dto.UserAuth;
 import org.example.outsourcing.domain.user.dto.request.UserDeleteRequest;
+import org.example.outsourcing.domain.user.dto.request.UserModifyRequest;
 import org.example.outsourcing.domain.user.dto.response.UserResponse;
 import org.example.outsourcing.domain.user.dto.request.UserSaveRequest;
 import org.example.outsourcing.domain.user.entity.Platform;
@@ -12,7 +14,6 @@ import org.example.outsourcing.domain.user.event.UserWithDrawEvent;
 import org.example.outsourcing.domain.user.exception.UserException;
 import org.example.outsourcing.domain.user.exception.UserExceptionCode;
 import org.example.outsourcing.domain.user.repository.UserRepository;
-import org.example.outsourcing.jwt.service.JwtService;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -26,15 +27,13 @@ public class UserService {
 
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
-	private final JwtService jwtService;
 	private final ApplicationEventPublisher publisher;
 
 	@Transactional
-	public UserResponse createUser(UserSaveRequest request) {
-
+	public void createUser(UserSaveRequest request) {
 		checkEmail(request.email());
 
-		User user = userRepository.save(
+		userRepository.save(
 			User.builder()
 				.email(request.email())
 				.name(request.name())
@@ -49,36 +48,52 @@ public class UserService {
 				.platform(Platform.LOCAL)
 				.build()
 		);
-		return UserResponse.from(user);
 	}
 
 	@Transactional
 	public void withDrawUser(UserDeleteRequest request, String accessToken) {
-
-		User user = userRepository.findByEmailAndPlatformAndIsDeleted(request.email(), Platform.LOCAL, false)
+		User user = userRepository.findByEmailAndIsDeleted(request.email(), false)
 			.orElseThrow(() -> new UserException(UserExceptionCode.USER_NOT_FOUND));
 
-		checkPassword(request.password(), user.getPassword());
+		if (user.getPlatform() == Platform.LOCAL) {
+			checkPassword(request.password(), user.getPassword());
+		}
+
 		user.withdraw();
 		publisher.publishEvent(new UserWithDrawEvent(accessToken));
 	}
 
-	/* 계정 탈퇴후, 로그아웃은 이벤트 방식으로 작동합니다. Redis 의 작업은 transaction 에 포함되지 않기 때문에
-	   탈퇴에 실패하고 로그아웃만 되는 현상이 발생할 수 있다고 가정하였습니다.
-	   해당 이벤트는 transaction 이 커밋된 이후에 발생합니다. */
+	@Transactional
+	public void modifyUser(UserModifyRequest request) {
+		User user = userRepository.findByEmailAndPlatformAndIsDeleted(
+				request.email(), Platform.LOCAL, false
+			)
+			.orElseThrow(() -> new UserException(UserExceptionCode.USER_NOT_FOUND));
+
+		checkPassword(request.password(), user.getPassword());
+		user.changeProfileInformation(
+			request.name(),
+			passwordEncoder.encode(request.newPassword())
+		);
+	}
+
+	@Transactional
+	public UserResponse viewUser(UserAuth userAuth) {
+		return UserResponse.from(
+			userRepository.findById(userAuth.getId())
+				.orElseThrow(() -> new UserException(UserExceptionCode.USER_NOT_FOUND))
+		);
+	}
 
 	private void checkEmail(String email) {
-
 		if (userRepository.existsByEmailAndPlatform(email, Platform.LOCAL)) {
 			throw new UserException(UserExceptionCode.ALREADY_EXISTS_EMAIL);
 		}
 	}
 
 	private void checkPassword(String rawPassword, String hashedPassword) {
-
 		if (!passwordEncoder.matches(rawPassword, hashedPassword)) {
 			throw new UserException(UserExceptionCode.WRONG_PASSWORD);
 		}
 	}
-
 }

--- a/src/main/java/org/example/outsourcing/jwt/service/JwtService.java
+++ b/src/main/java/org/example/outsourcing/jwt/service/JwtService.java
@@ -52,10 +52,6 @@ public class JwtService {
 		redisService.addBlackListToken(RedisToken.of(accessToken, ttl));
 	}
 
-	/* 아마 필터에서 만료된 토큰이 넘어오지는 않겠지만 만약을 가정하여
-	   블랙리스트에 저장시 만료된 토큰이면 redis 에 저장하지 않습니다
-	   그게 아니라면 ttl 값을 남은 만료시간만큼 계산하여 redis 에 저장합니다 */
-
 	public TokenResponse reissueToken(UserAuth userAuth, String refreshToken) {
 		if (jwtParser.isTokenExpired(refreshToken)) {
 			throw new TokenException(TokenExceptionCode.REFRESH_TOKEN_EXPIRED);


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #46  <!-- 연결된 이슈 번호 기재 -->



## ✨ 기능 요약

회원 삭제, 변경, 그리고 인가 로직 구현되었습니다.

<!--
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | 기능 이름을 간단히 요약 |
| 🔍 목적 | 해당 기능이 왜 필요한지 간략 설명 |
| 🛠️ 변경사항 | 핵심 변경 포인트 간략히 요약 (예: UI 추가, API 연동 등) |
--> 


## 📝 상세 내역

![image](https://github.com/user-attachments/assets/e1ed4a75-2a7f-462f-97b4-8fa2f324cc14)

사용자 정의 예외를 받아주는 ExceptionHandler 입니다.
따로 처리가 안되고 있길래 간단하게 생성했습니다.

![image](https://github.com/user-attachments/assets/a4116aa3-0ca4-4d92-982d-a019d43938bd)

Oauth 인증 실패시 호출되는 핸들러입니다. 세션 및 SecurityContext 를 파기하고 errorResponse 를 반환합니다.

![image](https://github.com/user-attachments/assets/2e0b82e8-ea8d-4d42-8c71-7baccc60999a)

인가 로직입니다
@PreAuthorize 선언하시고 안에 인가 로직을 구현한 메서드를 호출하시면 서비스 내부 중복되는 인가를 따로 정의해서 사용하실 수 있습니다.

![image](https://github.com/user-attachments/assets/cce4ba68-3096-410f-b96a-c2cd5524a4d2)

이런 식으로 구현하시면 됩니다. 예외 발생 시에는 사용자 정의 예외를 날려주심되여
추가적으로 해당 로직은 소셜 role 이 없으면 예외를 발생시킵니다. 

![image](https://github.com/user-attachments/assets/b3a0c7d7-a649-46ff-b15a-bf6f8d9477c8)
요런 식으로 and 조건도 줄수있습니다.
보안에 민감한 api 는 서비스 레이어 내부 접근 자체를 차단할 수 있습니다

<!--
| 번호 | 내용 |
|------|------|
| 1️⃣ | 주요 로직/컴포넌트/서비스 등 변경 설명 |
| 2️⃣ | 관련 유틸, 공통 로직 수정 여부 |
| 3️⃣ | 리팩토링 또는 제거된 불필요 코드 |
--> 


## ✅ 테스트 체크리스트
<!-- 테스트 할 내용이 있다면 작성해주세요
- [ ] 기능 정상 작동 확인
- [ ] 예외/엣지 케이스 확인
- [ ] UI/UX 흐름 확인 (필요 시 캡처 또는 영상 첨부)
- [ ] 테스트 코드 작성 완료
- [ ] API 연동 확인 (요청/응답 정상 동작)
--> 


## 📸 포스트맨 캡처 사진


## 🙋‍♀️ 리뷰어 참고사항


<!-- 
- 테스트 방법
- 주요 로직 설명
- 리뷰 시 중점적으로 봐주셨으면 하는 부분
- 코드 스타일 관련 사항 등
--> 
