### PR TITLE
[refactor] 리뷰 및 알림 서비스 UserAuth 주입 방식으로 리팩토링 #63

### DIFF
--- a/src/main/java/org/example/outsourcing/domain/notification/controller/NotificationController.java
+++ b/src/main/java/org/example/outsourcing/domain/notification/controller/NotificationController.java
@@ -1,14 +1,13 @@
 package org.example.outsourcing.domain.notification.controller;
 
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.example.outsourcing.common.annotation.ResponseMessage;
+import org.example.outsourcing.domain.auth.dto.UserAuth;
 import org.example.outsourcing.domain.notification.dto.request.NotificationRequestDto;
 import org.example.outsourcing.domain.notification.dto.response.NotificationResponseDto;
 import org.example.outsourcing.domain.notification.service.NotificationService;
-import org.example.outsourcing.domain.user.entity.User;
-import org.example.outsourcing.domain.user.repository.UserRepository;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -19,14 +18,12 @@ import java.util.List;
 public class NotificationController {
 
     private final NotificationService notificationService;
-    private final UserRepository userRepository;
 
     // 알림 목록 조회 (사용자별)
     @ResponseMessage("알림 목록을 성공적으로 조회했습니다.")
     @GetMapping
-    public ResponseEntity<List<NotificationResponseDto>> getNotifications(@RequestParam Long userId) {
-        User user = userRepository.findById(1L)
-                .orElseThrow(() -> new EntityNotFoundException("테스트 유저 없음"));
+    public ResponseEntity<List<NotificationResponseDto>> getNotifications(@AuthenticationPrincipal UserAuth userAuth) {
+        Long userId = userAuth.getId();
         List<NotificationResponseDto> notifications = notificationService.getNotifications(userId);
         return ResponseEntity.ok(notifications);
     }
@@ -34,8 +31,12 @@ public class NotificationController {
     // 알림 읽음 처리
     @ResponseMessage("알림을 읽었습니다.")
     @PutMapping
-    public ResponseEntity<Void> markAsRead(@RequestBody NotificationRequestDto requestDto) {
-        notificationService.markAsRead(requestDto);
+    public ResponseEntity<Void> markAsRead(
+            @AuthenticationPrincipal UserAuth userAuth,
+            @RequestBody NotificationRequestDto requestDto
+    ) {
+        Long userId = userAuth.getId();
+        notificationService.markAsRead(userId, requestDto);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/example/outsourcing/domain/notification/exception/NotificationExceptionCode.java
+++ b/src/main/java/org/example/outsourcing/domain/notification/exception/NotificationExceptionCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum NotificationExceptionCode implements ResponseCode {
     NOT_FOUND_FCMTOKEN(false, HttpStatus.NOT_FOUND, "FCM 토큰을 찾을 수 없습니다."),
-    NOT_FOUND_NOTIFICATION(false, HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다.");
+    NOT_FOUND_NOTIFICATION(false, HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다."),
+    NO_AUTH_FOR_NOTIFICATION(false, HttpStatus.FORBIDDEN, "알림에 대한 접근 권한이 없습니다.");
 
     private final boolean isSuccess;
     private final HttpStatus status;

--- a/src/main/java/org/example/outsourcing/domain/notification/service/NotificationService.java
+++ b/src/main/java/org/example/outsourcing/domain/notification/service/NotificationService.java
@@ -19,10 +19,10 @@ public class NotificationService {
 
     private final NotificationRepository notificationRepository;
 
-    // 알림 목록 조회 (사용자별로 알림 조회)
+    // 알림 목록 조회 (사용자별)
     @Transactional(readOnly = true)
     public List<NotificationResponseDto> getNotifications(Long userId) {
-        List<Notification> notifications = notificationRepository.findByUserId(userId);  // 사용자에 해당하는 알림 조회
+        List<Notification> notifications = notificationRepository.findByUserId(userId);
         return notifications.stream()
                 .map(notification -> new NotificationResponseDto(
                         notification.getId(),
@@ -32,12 +32,17 @@ public class NotificationService {
                 .collect(Collectors.toList());
     }
 
-    // 알림 읽음 처리 (알림을 읽은 상태로 업데이트)
+    // 알림 읽음 처리 (본인 알림만 읽을 수 있도록 userId 검증 추가)
     @Transactional
-    public void markAsRead(NotificationRequestDto requestDto) {
+    public void markAsRead(Long userId, NotificationRequestDto requestDto) {
         Notification notification = notificationRepository.findById(requestDto.notificationId())
                 .orElseThrow(() -> new NotificationException(NotificationExceptionCode.NOT_FOUND_NOTIFICATION));
+
+        // userId 검증 추가
+        if (!notification.getUser().getId().equals(userId)) {
+            throw new NotificationException(NotificationExceptionCode.NO_AUTH_FOR_NOTIFICATION);
+        }
+
         notification.markAsRead();
     }
-
 }

--- a/src/main/java/org/example/outsourcing/domain/review/controller/ReviewController.java
+++ b/src/main/java/org/example/outsourcing/domain/review/controller/ReviewController.java
@@ -1,15 +1,14 @@
 package org.example.outsourcing.domain.review.controller;
 
-import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.outsourcing.common.annotation.ResponseMessage;
+import org.example.outsourcing.domain.auth.dto.UserAuth;
 import org.example.outsourcing.domain.review.dto.request.ReviewRequestDto;
 import org.example.outsourcing.domain.review.dto.response.ReviewResponseDto;
 import org.example.outsourcing.domain.review.service.ReviewService;
-import org.example.outsourcing.domain.user.entity.User;
-import org.example.outsourcing.domain.user.repository.UserRepository;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -19,14 +18,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ReviewController {
     private final ReviewService reviewService;
-    private final UserRepository userRepository;
 
     @PostMapping
     @ResponseMessage("리뷰가 성공적으로 작성되었습니다.")
-    public ReviewRequestDto createReview(@Valid @RequestBody ReviewRequestDto reviewRequestDto) {
-        User user = userRepository.findById(1L)
-                .orElseThrow(() -> new EntityNotFoundException("테스트 유저 없음"));
-        reviewService.createReview(user.getId(), reviewRequestDto);
+    public ReviewRequestDto createReview(@AuthenticationPrincipal UserAuth userAuth, @Valid @RequestBody ReviewRequestDto reviewRequestDto) {
+        reviewService.createReview(userAuth, reviewRequestDto);
         return reviewRequestDto;
     }
 

--- a/src/main/java/org/example/outsourcing/domain/review/service/ReviewService.java
+++ b/src/main/java/org/example/outsourcing/domain/review/service/ReviewService.java
@@ -2,6 +2,8 @@ package org.example.outsourcing.domain.review.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.outsourcing.domain.auth.dto.UserAuth;
+import org.example.outsourcing.domain.order.entity.OrderStatus;
 import org.example.outsourcing.domain.review.dto.response.ReviewResponseDto;
 import org.example.outsourcing.domain.review.exception.ReviewException;
 import org.example.outsourcing.domain.review.exception.ReviewExceptionCode;
@@ -30,16 +32,16 @@ public class ReviewService {
     private final StoreRepository storeRepository;
 
     @Transactional
-    public void createReview(Long userId, ReviewRequestDto request) {
+    public void createReview(UserAuth userAuth, ReviewRequestDto request) {
         Order order = orderRepository.findById(request.orderId())
                 .orElseThrow(() -> new ReviewException(ReviewExceptionCode.ORDER_NOT_FOUND));
-        if (!order.getStatus().equals("COMPLETED")) {
+
+        if (!order.getStatus().equals(OrderStatus.COMPLETED)) {
             throw new ReviewException(ReviewExceptionCode.INVALID_REVIEW_CONDITION);
         }
 
-        User customer = userRepository.findById(userId)
+        User customer = userRepository.findById(userAuth.getId())
                 .orElseThrow(() -> new ReviewException(ReviewExceptionCode.USER_NOT_FOUND));
-
 
         Store store = storeRepository.findById(request.storeId())
                 .orElseThrow(() -> new ReviewException(ReviewExceptionCode.STORE_NOT_FOUND));
@@ -54,12 +56,10 @@ public class ReviewService {
                 .build();
 
         reviewRepository.save(review);
-
     }
 
-    @Transactional(readOnly=true)
+    @Transactional(readOnly = true)
     public List<ReviewResponseDto> getReviewList(Long storeId, int minRating, int maxRating) {
         return reviewRepository.findReviewListByStoreIdAndRatingBetween(storeId, minRating, maxRating);
     }
-
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #63


## ✨ 기능 요약
Long userId → UserAuth userAuth 방식으로 변경했습니다.


## 📝 상세 내역
번호 | 내용
--- | --
1️⃣  | 리뷰 생성, 리뷰 조회, 알림 조회, 알림 읽음 처리 기능에서 Long userId를 직접 받지 않고 UserAuth 객체를 주입받도록 변경했습니다.
2️⃣  | 서비스 레이어에서 인증된 사용자 정보를 직접 조회하여 일관성 있게 처리하도록 리팩토링했습니다.
3️⃣  | Controller와 Service 계층 모두 수정하여 인증 흐름을 통일했습니다.



## ✅ 테스트 체크리스트
- [x] 리뷰 생성 API 정상 동작 확인
- [x] 리뷰 조회 API 정상 동작 확인
- [x] 알림 조회 API 정상 동작 확인
- [x] 알림 읽음 처리 API 정상 동작 확인
- [x] 잘못된 토큰 또는 사용자 ID가 다른 경우 예외 처리 정상 확인


## 📸 Swagger 캡처 사진
리뷰 생성
![image](https://github.com/user-attachments/assets/e4e34ea4-1a40-4827-9139-fcdab4976421)

리뷰 목록 조회
![image](https://github.com/user-attachments/assets/79d30b10-c384-4125-b8b2-36bb871a815c)

알림 목록 조회
![image](https://github.com/user-attachments/assets/8181706e-fa8b-4c7d-9778-b7edb507b103)

알림 수정(읽음)
![image](https://github.com/user-attachments/assets/c2552137-5cde-45b5-93e0-6246e546445b)


